### PR TITLE
Added playing? boolean to Spotify Mac and iTunes Mac

### DIFF
--- a/lib/anyplayer/players/itunes_mac.rb
+++ b/lib/anyplayer/players/itunes_mac.rb
@@ -46,9 +46,8 @@ class Anyplayer::ItunesMac < Anyplayer::Player
   end
   
   def playing?
-    playing = %x(osascript -e 'tell app "iTunes"' -e 'if player state is playing then' -e  'return 1' -e 'else' -e 'return 0' -e  'end if' -e  'end tell').rstrip
-    playing == "1"? true : false 
-    puts playing
+    playing = itunes 'return player state is playing'
+    playing == "true" 
   end
 
   def launched?

--- a/lib/anyplayer/players/spotify_mac.rb
+++ b/lib/anyplayer/players/spotify_mac.rb
@@ -45,10 +45,9 @@ class Anyplayer::SpotifyMac < Anyplayer::Player
     spotify 'return album of current track'
   end
 
-  def playing?
-    playing = %x(osascript -e 'tell app "spotify"' -e 'if player state is playing then' -e  'return 1' -e 'else' -e 'return 0' -e  'end if' -e  'end tell').rstrip
-    playing == "1"? true : false 
-    puts playing
+  def playing?    
+    playing = spotify 'return player state is playing'
+    playing == "true"
   end
 
   def launched?


### PR DESCRIPTION
I added a playing? boolean to Spotify Mac and iTunes Mac. 

It returns true if the application is playing music, and false if it is not playing music. In the command line, it will return 1 if true and 0 if false. 
## Spotify Mac

I tested my feature out using the `ruby -Ilib bin/anyplayer` command that was in the README. Here are the results.
#### Playing is true

![screen shot 2013-06-25 at 11 44 16 am](https://f.cloud.github.com/assets/1711479/703714/399b9690-ddb0-11e2-8668-b7b8ed66822c.png)
#### Playing is false

![screen shot 2013-06-25 at 11 45 27 am](https://f.cloud.github.com/assets/1711479/703718/508b4ae4-ddb0-11e2-9c98-e30354db674e.png)
## iTunes Mac

Same testing as in Spotify Mac. Here are the results.
#### Playing is true

![screen shot 2013-06-25 at 12 03 37 pm](https://f.cloud.github.com/assets/1711479/703745/0aa96172-ddb1-11e2-9865-95a785b10e8d.png)
#### Playing is false

![screen shot 2013-06-25 at 12 03 52 pm](https://f.cloud.github.com/assets/1711479/703749/270d1c3c-ddb1-11e2-8583-d642ac4127d8.png)

---

This is my first pull request ever. If you need me to do anything else, I will gladly do it. 
